### PR TITLE
Changes to support BigQuery limitations, timestamp-millis logical type

### DIFF
--- a/src/java/org/apache/sqoop/config/ConfigurationConstants.java
+++ b/src/java/org/apache/sqoop/config/ConfigurationConstants.java
@@ -97,6 +97,11 @@ public final class ConfigurationConstants {
   public static final String PROP_ENABLE_AVRO_LOGICAL_TYPE_DECIMAL = "sqoop.avro.logical_types.decimal.enable";
 
   /**
+   * Enable avro logical type for dates.
+   */
+  public static final String PROP_ENABLE_AVRO_LOGICAL_TYPE_TIMESTAMP = "sqoop.avro.logical_types.timestamp.enable";
+
+  /**
    * Enable parquet logical types (decimal support only).
    */
   public static final String PROP_ENABLE_PARQUET_LOGICAL_TYPE_DECIMAL = "sqoop.parquet.logical_types.decimal.enable";
@@ -105,6 +110,16 @@ public final class ConfigurationConstants {
    * Default precision for avro schema
    */
   public static final String PROP_AVRO_DECIMAL_PRECISION = "sqoop.avro.logical_types.decimal.default.precision";
+
+  /**
+   * Maximum precision allowed in Avro conversions (if precision <= 38)
+   */
+  public static final String PROP_AVRO_MAXIMUM_PRECISION = "sqoop.avro.logical_types.decimal.default.precision.max";
+
+  /**
+   * Maximum scale allowed in Avro conversions, if greater than this value then rounded UP to this value
+   */
+  public static final String PROP_AVRO_MAXIMUM_SCALE = "sqoop.avro.logical_types.decimal.default.scale.max";
 
   /**
    * Default scale for avro schema

--- a/src/java/org/apache/sqoop/manager/ConnManager.java
+++ b/src/java/org/apache/sqoop/manager/ConnManager.java
@@ -212,6 +212,8 @@ public abstract class ConnManager {
     case Types.NVARCHAR:
     case Types.NCHAR:
       return Type.STRING;
+    case Types.CLOB:
+      return Type.STRING;
     case Types.DATE:
     case Types.TIME:
     case Types.TIMESTAMP:
@@ -220,6 +222,8 @@ public abstract class ConnManager {
     case Types.BINARY:
     case Types.VARBINARY:
     case Types.LONGVARBINARY:
+      return Type.BYTES;
+    case Types.ROWID:
       return Type.BYTES;
     default:
       throw new IllegalArgumentException("Cannot convert SQL type "

--- a/src/java/org/apache/sqoop/mapreduce/AvroImportMapper.java
+++ b/src/java/org/apache/sqoop/mapreduce/AvroImportMapper.java
@@ -70,7 +70,7 @@ public class AvroImportMapper
       throw new IOException(sqlE);
     }
 
-    GenericRecord outKey = AvroUtil.toGenericRecord(val.getFieldMap(), schema, bigDecimalFormatString, bigDecimalPadding);
+    GenericRecord outKey = AvroUtil.toGenericRecord(val.getFieldMap(), schema, bigDecimalFormatString, bigDecimalPadding, context);
     wrapper.datum(outKey);
     context.write(wrapper, NullWritable.get());
   }

--- a/src/java/org/apache/sqoop/mapreduce/MergeAvroReducer.java
+++ b/src/java/org/apache/sqoop/mapreduce/MergeAvroReducer.java
@@ -43,7 +43,7 @@ public class MergeAvroReducer extends MergeReducerBase<AvroWrapper<GenericRecord
   protected void writeRecord(SqoopRecord record, Context context)
       throws IOException, InterruptedException {
     GenericRecord outKey = AvroUtil.toGenericRecord(record.getFieldMap(), schema,
-        bigDecimalFormatString);
+        bigDecimalFormatString, null);
     wrapper.datum(outKey);
     context.write(wrapper, NullWritable.get());
   }

--- a/src/java/org/apache/sqoop/mapreduce/MergeParquetReducer.java
+++ b/src/java/org/apache/sqoop/mapreduce/MergeParquetReducer.java
@@ -68,7 +68,7 @@ public abstract class MergeParquetReducer<KEYOUT, VALUEOUT> extends Reducer<Text
 
       if (null != bestRecord) {
         GenericRecord record = AvroUtil.toGenericRecord(bestRecord.getFieldMap(), schema,
-            bigDecimalFormatString);
+            bigDecimalFormatString, null);
         write(context, record);
       }
     }

--- a/src/java/org/apache/sqoop/mapreduce/ParquetImportMapper.java
+++ b/src/java/org/apache/sqoop/mapreduce/ParquetImportMapper.java
@@ -68,7 +68,7 @@ public abstract class ParquetImportMapper<KEYOUT, VALOUT>
     }
 
     GenericRecord record = AvroUtil.toGenericRecord(val.getFieldMap(), schema,
-        bigDecimalFormatString, bigDecimalPadding);
+        bigDecimalFormatString, bigDecimalPadding, context);
     write(context, record);
   }
 


### PR DESCRIPTION
### New Sqoop features
- Support for Avro logical type "timestamp-millis" with flag -Dsqoop.avro.logical_types.timestamp.enable=true
- Support for a maximum precision for a numeric with -Dsqoop.avro.logical_types.decimal.default.precision.max
- Support for a maximum scale for a numeric with -Dsqoop.avro.logical_types.decimal.default.scale.max
- Support for Oracle CLOB columns (String)
- Support for Oracle RowId pseudo column (Bytes)

### Sqoop fixes
- Using --map-column-java and -Dsqoop.avro.logical_types.decimal.enable at the same time no longer throws an exception.