### PR TITLE
BigQuery support

### DIFF
--- a/src/java/org/apache/sqoop/avro/AvroUtil.java
+++ b/src/java/org/apache/sqoop/avro/AvroUtil.java
@@ -29,12 +29,16 @@ import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.mapred.FsInput;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.mapreduce.Mapper.Context;
 import org.apache.sqoop.config.ConfigurationConstants;
 import org.apache.sqoop.config.ConfigurationHelper;
 import org.apache.sqoop.lib.BlobRef;
@@ -47,9 +51,11 @@ import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.schema.MessageType;
 
 import java.io.IOException;
+import java.io.Reader;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.Date;
+import java.sql.RowId;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.List;
@@ -59,6 +65,8 @@ import java.util.Map;
  * The service class provides methods for creating and converting Avro objects.
  */
 public final class AvroUtil {
+
+  public static final Log LOG = LogFactory.getLog(AvroUtil.class.getName());
 
   public static final String DECIMAL = "decimal";
 
@@ -85,7 +93,7 @@ public final class AvroUtil {
     if(schemaContainingScale != null) {
       int scale = Integer.valueOf(schemaContainingScale.getObjectProp("scale").toString());
       if (bd.scale() != scale) {
-        return bd.setScale(scale);
+        return bd.setScale(scale, BigDecimal.ROUND_UP);
       }
     }
     return bd;
@@ -111,7 +119,7 @@ public final class AvroUtil {
   /**
    * Convert a Sqoop's Java representation to Avro representation.
    */
-  public static Object toAvro(Object o, Schema.Field field, boolean bigDecimalFormatString, boolean bigDecimalPaddingEnabled) {
+  public static Object toAvro(Object o, Schema.Field field, boolean bigDecimalFormatString, boolean bigDecimalPaddingEnabled, Context context) {
 
     if (o instanceof BigDecimal) {
       if(bigDecimalPaddingEnabled) {
@@ -134,6 +142,8 @@ public final class AvroUtil {
     } else if (o instanceof BytesWritable) {
       BytesWritable bw = (BytesWritable) o;
       return ByteBuffer.wrap(bw.getBytes(), 0, bw.getLength());
+    } else if (o instanceof RowId) {
+      return ByteBuffer.wrap(((RowId) o).getBytes());
     } else if (o instanceof BlobRef) {
       BlobRef br = (BlobRef) o;
       // If blob data is stored in an external .lob file, save the ref file
@@ -141,7 +151,22 @@ public final class AvroUtil {
       byte[] bytes = br.isExternal() ? br.toString().getBytes() : br.getData();
       return ByteBuffer.wrap(bytes);
     } else if (o instanceof ClobRef) {
-      throw new UnsupportedOperationException("ClobRef not supported");
+      ClobRef cr = (ClobRef) o;
+      if (!cr.isExternal()) {
+        return cr.toString();
+      }
+      if (context == null) {
+        throw new UnsupportedOperationException(
+            "need a mapper context to get an external ClobRef");
+      }
+      try {
+        Reader r = cr.getDataStream(context);
+        String ret = IOUtils.toString(r);
+        r.close();
+        return ret;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
     }
     // primitive types (Integer, etc) are left unchanged
     return o;
@@ -182,20 +207,20 @@ public final class AvroUtil {
   }
 
   public static GenericRecord toGenericRecord(Map<String, Object> fieldMap,
-                                              Schema schema, boolean bigDecimalFormatString) {
-    return toGenericRecord(fieldMap, schema, bigDecimalFormatString, false);
+                                              Schema schema, boolean bigDecimalFormatString, Context context) {
+    return toGenericRecord(fieldMap, schema, bigDecimalFormatString, false, context);
   }
 
   /**
    * Manipulate a GenericRecord instance.
    */
   public static GenericRecord toGenericRecord(Map<String, Object> fieldMap,
-      Schema schema, boolean bigDecimalFormatString, boolean bigDecimalPaddingEnabled) {
+      Schema schema, boolean bigDecimalFormatString, boolean bigDecimalPaddingEnabled, Context context) {
     GenericRecord record = new GenericData.Record(schema);
     for (Map.Entry<String, Object> entry : fieldMap.entrySet()) {
       String avroColumn = toAvroColumn(entry.getKey());
       Schema.Field field = schema.getField(avroColumn);
-      Object avroObject = toAvro(entry.getValue(), field, bigDecimalFormatString, bigDecimalPaddingEnabled);
+      Object avroObject = toAvro(entry.getValue(), field, bigDecimalFormatString, bigDecimalPaddingEnabled, context);
       record.put(avroColumn, avroObject);
     }
     return record;
@@ -311,6 +336,11 @@ public final class AvroUtil {
    * @return an avro decimal type, that can be added as a column type in the avro schema generation
    */
   public static LogicalType createDecimalType(Integer precision, Integer scale, Configuration conf) {
+    Integer configuredScale = ConfigurationHelper.getIntegerConfigIfExists(conf, ConfigurationConstants.PROP_AVRO_DECIMAL_SCALE);
+    if (configuredScale != null && scale == -127) {
+      // -127 is Number(*) stored "as is" (with a decimal point)
+      scale = configuredScale;
+    }
     if (precision == null || precision <= 0) {
       // we check if the user configured default precision and scale and use these values instead of invalid ones.
       Integer configuredPrecision = ConfigurationHelper.getIntegerConfigIfExists(conf, ConfigurationConstants.PROP_AVRO_DECIMAL_PRECISION);
@@ -320,14 +350,21 @@ public final class AvroUtil {
         throw new RuntimeException("Invalid precision for Avro Schema. Please specify a default precision with the -D" +
             ConfigurationConstants.PROP_AVRO_DECIMAL_PRECISION + " flag to avoid this issue.");
       }
-      Integer configuredScale = ConfigurationHelper.getIntegerConfigIfExists(conf, ConfigurationConstants.PROP_AVRO_DECIMAL_SCALE);
       if (configuredScale != null) {
         scale = configuredScale;
       }
     }
-
+    Integer configuredMaxScale = ConfigurationHelper.getIntegerConfigIfExists(conf, ConfigurationConstants.PROP_AVRO_MAXIMUM_SCALE);
+    if (configuredMaxScale != null && (scale > configuredMaxScale)) {
+      scale = configuredMaxScale;
+    }
+    Integer configuredMaxPrecision = ConfigurationHelper.getIntegerConfigIfExists(conf, ConfigurationConstants.PROP_AVRO_MAXIMUM_PRECISION);
+    if (configuredMaxPrecision != null && ((precision-scale > configuredMaxPrecision)) && scale >= 0) {
+      precision = configuredMaxPrecision+scale;
+    }
     return LogicalTypes.decimal(precision, scale);
   }
+
   private static Path getFileToTest(Path path, Configuration conf) throws IOException {
     FileSystem fs = path.getFileSystem(conf);
     if (!fs.isDirectory(path)) {

--- a/src/java/org/apache/sqoop/config/ConfigurationConstants.java
+++ b/src/java/org/apache/sqoop/config/ConfigurationConstants.java
@@ -97,6 +97,11 @@ public final class ConfigurationConstants {
   public static final String PROP_ENABLE_AVRO_LOGICAL_TYPE_DECIMAL = "sqoop.avro.logical_types.decimal.enable";
 
   /**
+   * Enable avro logical type for dates.
+   */
+  public static final String PROP_ENABLE_AVRO_LOGICAL_TYPE_TIMESTAMP = "sqoop.avro.logical_types.timestamp.enable";
+
+  /**
    * Enable parquet logical types (decimal support only).
    */
   public static final String PROP_ENABLE_PARQUET_LOGICAL_TYPE_DECIMAL = "sqoop.parquet.logical_types.decimal.enable";
@@ -105,6 +110,16 @@ public final class ConfigurationConstants {
    * Default precision for avro schema
    */
   public static final String PROP_AVRO_DECIMAL_PRECISION = "sqoop.avro.logical_types.decimal.default.precision";
+
+  /**
+   * Maximum precision (minus scale) allowed in Avro conversions
+   */
+  public static final String PROP_AVRO_MAXIMUM_PRECISION = "sqoop.avro.logical_types.decimal.default.precision.max";
+
+  /**
+   * Maximum scale allowed in Avro conversions, if greater than this value then rounded UP to this value
+   */
+  public static final String PROP_AVRO_MAXIMUM_SCALE = "sqoop.avro.logical_types.decimal.default.scale.max";
 
   /**
    * Default scale for avro schema

--- a/src/java/org/apache/sqoop/manager/ConnManager.java
+++ b/src/java/org/apache/sqoop/manager/ConnManager.java
@@ -212,6 +212,8 @@ public abstract class ConnManager {
     case Types.NVARCHAR:
     case Types.NCHAR:
       return Type.STRING;
+    case Types.CLOB:
+      return Type.STRING;
     case Types.DATE:
     case Types.TIME:
     case Types.TIMESTAMP:
@@ -220,6 +222,8 @@ public abstract class ConnManager {
     case Types.BINARY:
     case Types.VARBINARY:
     case Types.LONGVARBINARY:
+      return Type.BYTES;
+    case Types.ROWID:
       return Type.BYTES;
     default:
       throw new IllegalArgumentException("Cannot convert SQL type "

--- a/src/java/org/apache/sqoop/mapreduce/AvroImportMapper.java
+++ b/src/java/org/apache/sqoop/mapreduce/AvroImportMapper.java
@@ -70,7 +70,7 @@ public class AvroImportMapper
       throw new IOException(sqlE);
     }
 
-    GenericRecord outKey = AvroUtil.toGenericRecord(val.getFieldMap(), schema, bigDecimalFormatString, bigDecimalPadding);
+    GenericRecord outKey = AvroUtil.toGenericRecord(val.getFieldMap(), schema, bigDecimalFormatString, bigDecimalPadding, context);
     wrapper.datum(outKey);
     context.write(wrapper, NullWritable.get());
   }

--- a/src/java/org/apache/sqoop/mapreduce/MergeAvroReducer.java
+++ b/src/java/org/apache/sqoop/mapreduce/MergeAvroReducer.java
@@ -43,7 +43,7 @@ public class MergeAvroReducer extends MergeReducerBase<AvroWrapper<GenericRecord
   protected void writeRecord(SqoopRecord record, Context context)
       throws IOException, InterruptedException {
     GenericRecord outKey = AvroUtil.toGenericRecord(record.getFieldMap(), schema,
-        bigDecimalFormatString);
+        bigDecimalFormatString, null);
     wrapper.datum(outKey);
     context.write(wrapper, NullWritable.get());
   }

--- a/src/java/org/apache/sqoop/mapreduce/MergeParquetReducer.java
+++ b/src/java/org/apache/sqoop/mapreduce/MergeParquetReducer.java
@@ -68,7 +68,7 @@ public abstract class MergeParquetReducer<KEYOUT, VALUEOUT> extends Reducer<Text
 
       if (null != bestRecord) {
         GenericRecord record = AvroUtil.toGenericRecord(bestRecord.getFieldMap(), schema,
-            bigDecimalFormatString);
+            bigDecimalFormatString, null);
         write(context, record);
       }
     }

--- a/src/java/org/apache/sqoop/mapreduce/ParquetImportMapper.java
+++ b/src/java/org/apache/sqoop/mapreduce/ParquetImportMapper.java
@@ -68,7 +68,7 @@ public abstract class ParquetImportMapper<KEYOUT, VALOUT>
     }
 
     GenericRecord record = AvroUtil.toGenericRecord(val.getFieldMap(), schema,
-        bigDecimalFormatString, bigDecimalPadding);
+        bigDecimalFormatString, bigDecimalPadding, context);
     write(context, record);
   }
 


### PR DESCRIPTION
### New Sqoop features
- Support for Avro logical type "timestamp-millis" with flag -Dsqoop.avro.logical_types.timestamp.enable=true
- Support for a maximum (precision minus scale) for a numeric with -Dsqoop.avro.logical_types.decimal.default.precision.max
- Support for a maximum scale for a numeric with -Dsqoop.avro.logical_types.decimal.default.scale.max
- Support for Oracle CLOB columns (String)
- Support for Oracle RowId pseudo column (Bytes)

### Sqoop fixes
- Using --map-column-java and -Dsqoop.avro.logical_types.decimal.enable at the same time no longer throws an exception.

Signed-off-by: Joe Mesterhazy <jmesterh@stanford.edu>